### PR TITLE
Setting rehash to true.

### DIFF
--- a/completions.plugin.zsh
+++ b/completions.plugin.zsh
@@ -37,6 +37,9 @@ zstyle ':completion:*:*:*:*:descriptions' format '%F{blue}-- %D %d --%f'
 zstyle ':completion:*:*:*:*:messages' format ' %F{purple} -- %d --%f'
 zstyle ':completion:*:*:*:*:warnings' format ' %F{red}-- no matches found --%f'
 
+# Automatically find new executables in path
+zstyle ':completion:*' rehash true
+
 # Colors for files and directory
 zstyle ':completion:*:*:*:*:default' list-colors ${(s.:.)LS_COLORS}
 


### PR DESCRIPTION
Setting rehash to true for ability to automatically load new executables without having to reload the shell.

#### Example 1

Installed a new program and you want to get completions for it like for example `trash-cli`, with this option you don't have to reload the shell to get all `trash-*` commands.

##### Example 2

You make a script in your path and you make a stupid long name (victim of it myself) for it and wanna autocomplete it in the same session.

I think that this a a very sensible setting and good for daily use.